### PR TITLE
feat: Add grids CustomPainter

### DIFF
--- a/lib/src/painters/events_painters.dart
+++ b/lib/src/painters/events_painters.dart
@@ -270,3 +270,89 @@ class ColumnPainter extends CustomPainter {
   @override
   bool shouldRepaint(ColumnPainter oldDelegate) => true;
 }
+
+class GridsPainter extends CustomPainter {
+  final double width;
+  final double heightPerMinute;
+  final Color lineColor;
+  final double hourStrokeWidth;
+  final double halfStrokeWidth;
+  final double quarterStrokeWidth;
+  final bool drawHalfHour;
+  final bool drawQuarterHour;
+
+  GridsPainter({
+    super.repaint,
+    required this.width,
+    required this.heightPerMinute,
+    required this.lineColor,
+    this.hourStrokeWidth = 0.5,
+    this.halfStrokeWidth = 0.2,
+    this.quarterStrokeWidth = 0.1,
+    this.drawHalfHour = true,
+    this.drawQuarterHour = true,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()..color = lineColor;
+
+    canvas.drawLine(Offset(0, 0), Offset(0, size.height), paint);
+
+    final cellHeight = heightPerMinute * 60;
+
+    final hourPaint = Paint()
+      ..color = lineColor
+      ..strokeWidth = hourStrokeWidth;
+
+    final halfHourPaint = Paint()
+      ..color = lineColor
+      ..strokeWidth = halfStrokeWidth;
+
+    final quarterHourPaint = Paint()
+      ..color = lineColor
+      ..strokeWidth = quarterStrokeWidth;
+
+    for (var i = 0; i < 24; i++) {
+      final hourY = i * cellHeight;
+      canvas.drawLine(Offset(0, hourY), Offset(size.width, hourY), hourPaint);
+
+      if (drawHalfHour) {
+        final halfHourY = hourY + cellHeight / 2;
+        canvas.drawLine(
+          Offset(0, halfHourY),
+          Offset(size.width, halfHourY),
+          halfHourPaint,
+        );
+      }
+
+      if (drawQuarterHour) {
+        if (heightPerMinute > 2) {
+          final quarterHourY15 = hourY + cellHeight / 4;
+          final quarterHourY45 = hourY + 3 * cellHeight / 4;
+
+          canvas.drawLine(
+            Offset(0, quarterHourY15),
+            Offset(size.width, quarterHourY15),
+            quarterHourPaint,
+          );
+          canvas.drawLine(
+            Offset(0, quarterHourY45),
+            Offset(size.width, quarterHourY45),
+            quarterHourPaint,
+          );
+        }
+      }
+    }
+
+    // Draw 24:00 line
+    canvas.drawLine(
+      Offset(0, 24 * cellHeight),
+      Offset(size.width, 24 * cellHeight),
+      hourPaint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(GridsPainter oldDelegate) => true;
+}


### PR DESCRIPTION
Simple grid custom painter that extends on the columns and hours painter with some minor tweaks on a few options(due to my use case).

# Description

Extension on previous custom painters, as none suited my use case. Essentially draws a grid for time slots.

<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->

## Checklist

<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

<!--
Would your PR require CalendarView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues

Closes #29 

<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->

[Contributor Guide]: https://github.com/pickywawa/infinite_calendar_view/blob/master/CONTRIBUTING.md

[Conventional Commit]: https://conventionalcommits.org