### PR TITLE
feat: add daysWidthRatio for variable day widths and fix drag-and-drop offset

### DIFF
--- a/example/lib/app.dart
+++ b/example/lib/app.dart
@@ -53,6 +53,7 @@ class _AppState extends State<App> {
           constraints: BoxConstraints(
             maxWidth: switch (calendarMode) {
               Mode.day7 => double.infinity,
+              Mode.day7SmallWeekends => double.infinity,
               Mode.day3Rotation => 1000,
               Mode.day3RotationMultiColumn => 1000,
               _ => 500,
@@ -119,6 +120,7 @@ class CalendarViewWidget extends StatelessWidget {
       Mode.day3Draggable => PlannerEventsDrag(key: UniqueKey(), daysShowed: 3),
       Mode.day3Slot => PlannerTreeDaysSlot(key: UniqueKey()),
       Mode.day7 => PlannerEventsDrag(key: UniqueKey(), daysShowed: 7),
+      Mode.day7SmallWeekends => PlannerEventsDrag(key: UniqueKey(), daysShowed: 7, daysWidthRatio: [1, 1, 1, 1, 1, 0.6, 0.6]),
       Mode.multiColumn => PlannerMultiColumns(key: UniqueKey()),
       Mode.multiColumn2 => PlannerMultiColumns2(key: UniqueKey()),
       Mode.month => Months(key: UniqueKey()),

--- a/example/lib/enumerations.dart
+++ b/example/lib/enumerations.dart
@@ -10,6 +10,7 @@ enum Mode {
   multiColumn("Multi columns 1", Icons.view_column_outlined),
   multiColumn2("Multi columns 2", Icons.view_column_outlined),
   day7("Seven days (web or tablet)", Icons.calendar_view_week),
+  day7SmallWeekends("Seven days - Smaller Weekends", Icons.calendar_view_week),
   day3RTL("Three days RTL (Arabic, Hebrew etc.)", Icons.view_column),
   monthRTL("Month RTL (Arabic, Hebrew etc.)", Icons.calendar_month),
   day3Rotation("Three days horizontal (rotation)", Icons.view_list),

--- a/example/lib/views/events_planner_draggable_events_example.dart
+++ b/example/lib/views/events_planner_draggable_events_example.dart
@@ -10,9 +10,11 @@ class PlannerEventsDrag extends StatelessWidget {
   const PlannerEventsDrag({
     super.key,
     required this.daysShowed,
+    this.daysWidthRatio,
   });
 
   final int daysShowed;
+  final List<double>? daysWidthRatio;
 
   @override
   Widget build(BuildContext context) {
@@ -22,6 +24,7 @@ class PlannerEventsDrag extends StatelessWidget {
     return EventsPlanner(
       controller: eventsController,
       daysShowed: daysShowed,
+      daysWidthRatio: daysWidthRatio,
       heightPerMinute: heightPerMinute,
       initialVerticalScrollOffset: initialVerticalScrollOffset,
       dayParam: DayParam(

--- a/lib/src/events_planner.dart
+++ b/lib/src/events_planner.dart
@@ -140,6 +140,8 @@ class EventsPlanner extends StatefulWidget {
 
   /// Array of 7 doubles representing the flex ratio of each day (Mon-Sun)
   /// Example: [1.0, 1.0, 1.0, 1.0, 1.0, 0.5, 0.5]
+  /// Note: [daysShowed] acts as the viewport capacity for standard (1.0) days.
+  /// Days with a ratio > 1.0 will expand proportionately, meaning you may need to scroll to see all [daysShowed] days at once.
   final List<double>? daysWidthRatio;
 
   @override

--- a/lib/src/events_planner.dart
+++ b/lib/src/events_planner.dart
@@ -347,9 +347,11 @@ class EventsPlannerState extends State<EventsPlanner> {
   }
 
   /// Finds the day index based on the current scroll offset in pixels
-  int getIndexForOffset(double offset) {
+  /// If [findExact] is true, it strictly finds the boundary the offset falls into (used for dragging).
+  /// If [findExact] is false, it finds the nearest day center (used for scroll snapping).
+  int getIndexForOffset(double offset, {bool findExact = false}) {
     if (widget.daysWidthRatio == null || widget.daysWidthRatio!.length != 7) {
-      return (offset / dayWidth).round();
+      return findExact ? (offset / dayWidth).floor() : (offset / dayWidth).round();
     }
 
     double weekWidth = dayWidth * 7;
@@ -359,10 +361,12 @@ class EventsPlannerState extends State<EventsPlanner> {
     int index = weeks * 7;
     double currentOffset = 0;
 
-    // Accumulate day widths until we reach the center of the target day
+    // Accumulate day widths until we reach the target day
     while (true) {
       double currentDayWidth = getDayWidth(getDayFromIndex(index));
-      if (currentOffset + (currentDayWidth / 2) > remainingOffset) {
+      double threshold = findExact ? currentDayWidth : (currentDayWidth / 2);
+
+      if (currentOffset + threshold > remainingOffset) {
         return index;
       }
       currentOffset += currentDayWidth;

--- a/lib/src/events_planner.dart
+++ b/lib/src/events_planner.dart
@@ -23,6 +23,7 @@ class EventsPlanner extends StatefulWidget {
     required this.controller,
     this.initialDate,
     this.daysShowed = 3,
+    this.daysWidthRatio,
     this.textDirection = TextDirection.ltr,
     this.maxPreviousDays = 365,
     this.maxNextDays = 365,
@@ -48,7 +49,10 @@ class EventsPlanner extends StatefulWidget {
     this.offTimesParam = const OffTimesParam(),
     this.pinchToZoomParam = const PinchToZoomParameters(),
     this.fullDayParam = const FullDayParam(),
-  });
+  }) : assert(
+    daysWidthRatio == null || daysWidthRatio.length == 7,
+    'daysWidthRatio must contain exactly 7 elements representing the flex units for Monday through Sunday.',
+  );
 
   /// data controller
   final EventsController controller;
@@ -133,6 +137,10 @@ class EventsPlanner extends StatefulWidget {
 
   // full day parameters
   final FullDayParam fullDayParam;
+
+  /// Array of 7 doubles representing the flex ratio of each day (Mon-Sun)
+  /// Example: [1.0, 1.0, 1.0, 1.0, 1.0, 0.5, 0.5]
+  final List<double>? daysWidthRatio;
 
   @override
   State createState() => EventsPlannerState();
@@ -235,12 +243,10 @@ class EventsPlannerState extends State<EventsPlanner> {
 
   /// listen mainHorizontalController and call onFirstDayChange when day change
   void initDayChangingListener() {
-    var halfDayWidth = (dayWidth / 2);
     var scroll = mainHorizontalController;
     scroll.addListener(() {
       if (_listenHorizontalScrollDayChange) {
-        var halfDay = scroll.offset >= 0 ? halfDayWidth : -halfDayWidth;
-        var index = ((scroll.offset + halfDay) / dayWidth).toInt();
+        var index = getIndexForOffset(scroll.offset);
         // only when index has changed
         if (index != currentIndex) {
           currentIndex = index;
@@ -263,8 +269,9 @@ class EventsPlannerState extends State<EventsPlanner> {
       var scroll = mainHorizontalController;
       var stopScroll = !scroll.position.isScrollingNotifier.value;
       if (_listenHorizontalScrollDayChange && stopScroll) {
-        // Round to nearest day
-        var nearestDayOffset = dayWidth * (scroll.offset / dayWidth).round();
+        // use dynamic offset rounding
+        var nearestIndex = getIndexForOffset(scroll.offset);
+        var nearestDayOffset = getOffsetForIndex(nearestIndex);
         if (nearestDayOffset != scroll.offset) {
           // adjust scroll
           Future.delayed(const Duration(milliseconds: 1), () {
@@ -297,6 +304,70 @@ class EventsPlannerState extends State<EventsPlanner> {
       }
     }
     return false;
+  }
+
+  /// Gets the dynamic width for a specific day based on daysWidthRatio
+  double getDayWidth(DateTime day) {
+    if (widget.daysWidthRatio == null || widget.daysWidthRatio!.length != 7) {
+      return dayWidth; // Fallback to standard calculated width
+    }
+
+    // Sum of the ratios
+    double totalFlex = widget.daysWidthRatio!.reduce((a, b) => a + b);
+
+    // We scale the width proportionally to respect `widget.daysShowed`.
+    // averageFlex represents the flex of a standard "1.0" day.
+    double averageFlex = totalFlex / 7.0;
+    double baseWidth = dayWidth / averageFlex;
+
+    return baseWidth * widget.daysWidthRatio![day.weekday - 1];
+  }
+
+  /// Calculates the exact scroll offset in pixels for a given day index
+  double getOffsetForIndex(int index) {
+    if (widget.daysWidthRatio == null || widget.daysWidthRatio!.length != 7) {
+      return index * dayWidth;
+    }
+
+    // The width of a full 7-day week is ALWAYS exactly 7 * dayWidth
+    // because our ratios are proportionally scaled.
+    double weekWidth = dayWidth * 7;
+
+    // Using double division and floor() correctly handles negative numbers in Dart
+    int weeks = (index / 7).floor();
+    int remainder = index - (weeks * 7); // Always a positive index from 0 to 6
+
+    double offset = weeks * weekWidth;
+
+    // Add the specific widths for the remaining days
+    for (int i = 0; i < remainder; i++) {
+      offset += getDayWidth(getDayFromIndex(weeks * 7 + i));
+    }
+    return offset;
+  }
+
+  /// Finds the day index based on the current scroll offset in pixels
+  int getIndexForOffset(double offset) {
+    if (widget.daysWidthRatio == null || widget.daysWidthRatio!.length != 7) {
+      return (offset / dayWidth).round();
+    }
+
+    double weekWidth = dayWidth * 7;
+    int weeks = (offset / weekWidth).floor();
+    double remainingOffset = offset - (weeks * weekWidth);
+
+    int index = weeks * 7;
+    double currentOffset = 0;
+
+    // Accumulate day widths until we reach the center of the target day
+    while (true) {
+      double currentDayWidth = getDayWidth(getDayFromIndex(index));
+      if (currentOffset + (currentDayWidth / 2) > remainingOffset) {
+        return index;
+      }
+      currentOffset += currentDayWidth;
+      index++;
+    }
   }
 
   @override
@@ -477,7 +548,7 @@ class EventsPlannerState extends State<EventsPlanner> {
                 daySeparationWidthPadding: daySeparationWidthPadding,
                 plannerHeight: plannerHeight,
                 heightPerMinute: heightPerMinute,
-                dayWidth: dayWidth,
+                dayWidth: getDayWidth(day),
                 dayEventsArranger: widget.dayEventsArranger,
                 dayParam: widget.dayParam,
                 columnsParam: widget.columnsParam,
@@ -521,7 +592,7 @@ class EventsPlannerState extends State<EventsPlanner> {
       maxPreviousDays: widget.maxPreviousDays,
       maxNextDays: widget.maxNextDays,
       initialDate: initialDate,
-      dayWidth: dayWidth,
+      dayWidthBuilder: getDayWidth,
       todayColor: todayColor,
       timesIndicatorsWidth: widget.timesIndicatorsParam.timesIndicatorsWidth,
     );
@@ -541,7 +612,7 @@ class EventsPlannerState extends State<EventsPlanner> {
       maxPreviousDays: widget.maxPreviousDays,
       maxNextDays: widget.maxNextDays,
       initialDate: initialDate,
-      dayWidth: dayWidth,
+      dayWidthBuilder: getDayWidth,
       timesIndicatorsWidth: widget.timesIndicatorsParam.timesIndicatorsWidth,
       topLeftCellValueNotifier: topLeftCellValueNotifier,
     );
@@ -630,7 +701,7 @@ class EventsPlannerState extends State<EventsPlanner> {
       // stop scroll listener for avoid change day listener
       _listenHorizontalScrollDayChange = false;
       var index = date.withoutTime.getDayDifference(initialDate);
-      var offset = index * dayWidth;
+      var offset = getOffsetForIndex(index);
       if (widget.textDirection == TextDirection.rtl) {
         offset = -offset;
       }

--- a/lib/src/events_planner.dart
+++ b/lib/src/events_planner.dart
@@ -31,6 +31,7 @@ class EventsPlanner extends StatefulWidget {
     this.daySeparationWidth = 3.0,
     this.dayEventsArranger = const SideEventArranger(),
     this.onDayChange,
+    this.onSettledDayChange,
     this.initialVerticalScrollOffset = 0,
     this.minVerticalScrollOffset,
     this.maxVerticalScrollOffset,
@@ -87,6 +88,12 @@ class EventsPlanner extends StatefulWidget {
 
   /// Callback when first day (showed in planner) change during horizontal scroll
   final void Function(DateTime firstDay)? onDayChange;
+
+  /// Callback when the horizontal scroll settles on the first shown day.
+  ///
+  /// Use this when parent state should only react to the final snapped page,
+  /// not to transient days revealed during a drag.
+  final void Function(DateTime firstDay)? onSettledDayChange;
 
   /// initial time scroll (vertical) : hour of day = heightPerMinute * $total_minutes
   final double initialVerticalScrollOffset;
@@ -164,9 +171,21 @@ class EventsPlannerState extends State<EventsPlanner> {
   late double heightPerMinuteScaleStart;
   late double mainVerticalControllerOffsetScaleStart;
   var _listenHorizontalScrollDayChange = true;
+  int? _lastSettledIndex;
   var _plannerPointerDownCount = 0;
   var _isKeyboardZoomActive = false;
   var _startColumnIndex = 0;
+
+  // With day width ratios, the scroll view uses fixed-width pages instead of
+  // variable-width day slivers. The days inside each page still keep their
+  // ratio-based widths, but Flutter can lay out the scroll geometry reliably.
+  bool get _usesFixedExtentPages =>
+      widget.daysWidthRatio != null && widget.daysWidthRatio!.isNotEmpty;
+
+  // The fixed page width is the unscaled width of all ratio-based days it
+  // contains.
+  double? get _horizontalItemExtent =>
+      _usesFixedExtentPages ? dayWidth * widget.daysWidthRatio!.length : null;
 
   @override
   void initState() {
@@ -198,6 +217,7 @@ class EventsPlannerState extends State<EventsPlanner> {
         mainHorizontalController.position.isScrollingNotifier
             .addListener(automaticScrollAdjustListener);
       }
+      mainHorizontalController.position.isScrollingNotifier.addListener(_handleHorizontalScrollSettled);
 
       // init vertical scroll listener when scroll stop
       if (widget.onVerticalScrollChange != null) {
@@ -239,6 +259,9 @@ class EventsPlannerState extends State<EventsPlanner> {
 
   @override
   void dispose() {
+    if (mainHorizontalController.hasClients) {
+      mainHorizontalController.position.isScrollingNotifier.removeListener(_handleHorizontalScrollSettled);
+    }
     HardwareKeyboard.instance.removeHandler(_handleKeyEvent);
     super.dispose();
   }
@@ -263,6 +286,64 @@ class EventsPlannerState extends State<EventsPlanner> {
     });
   }
 
+  /// Calls [EventsPlanner.onSettledDayChange] after horizontal scrolling snaps.
+  void _handleHorizontalScrollSettled() {
+    var scroll = mainHorizontalController;
+    if (!scroll.hasClients ||
+        scroll.position.isScrollingNotifier.value ||
+        !_listenHorizontalScrollDayChange) {
+      return;
+    }
+
+    // Give optional automatic day adjustment a chance to start first.
+    Future.delayed(const Duration(milliseconds: 1), () {
+      if (!mounted ||
+          !scroll.hasClients ||
+          scroll.position.isScrollingNotifier.value ||
+          !_listenHorizontalScrollDayChange) {
+        return;
+      }
+
+      _notifyHorizontalScrollSettled();
+    });
+  }
+
+  void _notifyHorizontalScrollSettled() {
+    var scroll = mainHorizontalController;
+    var settledIndex = getIndexForOffset(scroll.offset);
+    _jumpHorizontalScrollToIndex(settledIndex);
+    currentIndex = settledIndex;
+    if (settledIndex == _lastSettledIndex) {
+      return;
+    }
+    _lastSettledIndex = settledIndex;
+
+    var settledDay = widget.textDirection == TextDirection.ltr
+        ? getDayFromIndex(settledIndex)
+        : getDayFromIndex(settledIndex + widget.daysShowed - 1);
+    widget.onSettledDayChange?.call(settledDay);
+    widget.controller.updateFocusedDay(settledDay);
+    topLeftCellValueNotifier.value = settledDay;
+  }
+
+  void _jumpHorizontalScrollToIndex(int index) {
+    if (!mainHorizontalController.hasClients) {
+      return;
+    }
+
+    var targetOffset = getOffsetForIndex(index);
+    if (widget.textDirection == TextDirection.rtl) {
+      targetOffset = -targetOffset;
+    }
+    if ((mainHorizontalController.offset - targetOffset).abs() < 0.5) {
+      return;
+    }
+
+    _listenHorizontalScrollDayChange = false;
+    mainHorizontalController.jumpTo(targetOffset);
+    _listenHorizontalScrollDayChange = true;
+  }
+
   /// listen mainHorizontalController scroll stop and adjust to nearest day
   /// call onAutomaticAdjustHorizontalScroll when end adjust
   VoidCallback getAutomaticScrollAdjustListener() {
@@ -282,8 +363,7 @@ class EventsPlannerState extends State<EventsPlanner> {
                 curve: Curves.easeIn);
 
             // event
-            var adjustedDay =
-                getDayFromIndex((nearestDayOffset / dayWidth).toInt());
+            var adjustedDay = getDayFromIndex(nearestIndex);
             widget.onAutomaticAdjustHorizontalScroll?.call(adjustedDay);
           });
         }
@@ -319,10 +399,17 @@ class EventsPlannerState extends State<EventsPlanner> {
 
     // We scale the width proportionally to respect `widget.daysShowed`.
     // averageFlex represents the flex of a standard "1.0" day.
-    double averageFlex = totalFlex / 7.0;
+    double averageFlex = totalFlex / widget.daysWidthRatio!.length;
     double baseWidth = dayWidth / averageFlex;
 
     return baseWidth * widget.daysWidthRatio![day.weekday - 1];
+  }
+
+  int? _listItemCountForMaxDays(int? maxDays) {
+    if (!_usesFixedExtentPages || maxDays == null) {
+      return maxDays;
+    }
+    return (maxDays / widget.daysWidthRatio!.length).ceil();
   }
 
   /// Calculates the exact scroll offset in pixels for a given day index
@@ -331,19 +418,20 @@ class EventsPlannerState extends State<EventsPlanner> {
       return index * dayWidth;
     }
 
-    // The width of a full 7-day week is ALWAYS exactly 7 * dayWidth
-    // because our ratios are proportionally scaled.
-    double weekWidth = dayWidth * 7;
+    // The full ratio period keeps a stable total width because ratios are
+    // proportionally scaled.
+    var periodLength = widget.daysWidthRatio!.length;
+    double periodWidth = dayWidth * periodLength;
 
     // Using double division and floor() correctly handles negative numbers in Dart
-    int weeks = (index / 7).floor();
-    int remainder = index - (weeks * 7); // Always a positive index from 0 to 6
+    int periods = (index / periodLength).floor();
+    int remainder = index - (periods * periodLength);
 
-    double offset = weeks * weekWidth;
+    double offset = periods * periodWidth;
 
     // Add the specific widths for the remaining days
     for (int i = 0; i < remainder; i++) {
-      offset += getDayWidth(getDayFromIndex(weeks * 7 + i));
+      offset += getDayWidth(getDayFromIndex(periods * periodLength + i));
     }
     return offset;
   }
@@ -356,11 +444,12 @@ class EventsPlannerState extends State<EventsPlanner> {
       return findExact ? (offset / dayWidth).floor() : (offset / dayWidth).round();
     }
 
-    double weekWidth = dayWidth * 7;
-    int weeks = (offset / weekWidth).floor();
-    double remainingOffset = offset - (weeks * weekWidth);
+    var periodLength = widget.daysWidthRatio!.length;
+    double periodWidth = dayWidth * periodLength;
+    int periods = (offset / periodWidth).floor();
+    double remainingOffset = offset - (periods * periodWidth);
 
-    int index = weeks * 7;
+    int index = periods * periodLength;
     double currentOffset = 0;
 
     // Accumulate day widths until we reach the target day
@@ -526,6 +615,29 @@ class EventsPlannerState extends State<EventsPlanner> {
         ? const NeverScrollableScrollPhysics()
         : widget.horizontalScrollPhysics;
 
+    if (_usesFixedExtentPages) {
+      // Use fixed sliver pages for stable scroll geometry while keeping
+      // variable day widths inside each page.
+      return InfiniteList(
+        controller: mainHorizontalController,
+        scrollDirection: Axis.horizontal,
+        direction: InfiniteListDirection.multi,
+        negChildCount: _listItemCountForMaxDays(widget.maxPreviousDays),
+        posChildCount: _listItemCountForMaxDays(widget.maxNextDays),
+        itemExtent: _horizontalItemExtent,
+        physics: physics,
+        builder: (context, index) => InfiniteListItem(
+          contentBuilder: (context) => _buildPlannerFixedExtentPage(
+            index,
+            todayColor,
+            daySeparationWidthPadding,
+            plannerHeight,
+            currentHourIndicatorColor,
+          ),
+        ),
+      );
+    }
+
     return ScrollConfiguration(
       behavior: ScrollConfiguration.of(context).copyWith(
         scrollbars: false,
@@ -546,28 +658,78 @@ class EventsPlannerState extends State<EventsPlanner> {
 
           return InfiniteListItem(
             contentBuilder: (context) {
-              return DayWidget(
-                controller: _controller,
-                textDirection: widget.textDirection,
-                day: day,
-                todayColor: todayColor,
-                daySeparationWidthPadding: daySeparationWidthPadding,
-                plannerHeight: plannerHeight,
-                heightPerMinute: heightPerMinute,
-                dayWidth: getDayWidth(day),
-                dayEventsArranger: widget.dayEventsArranger,
-                dayParam: widget.dayParam,
-                columnsParam: widget.columnsParam,
-                startColumnIndex: _startColumnIndex,
-                currentHourIndicatorParam: widget.currentHourIndicatorParam,
-                currentHourIndicatorColor: currentHourIndicatorColor,
-                offTimesParam: widget.offTimesParam,
-                showMultiDayEvents: !widget.fullDayParam.showMultiDayEvents,
+              return _buildDayWidget(
+                index,
+                todayColor,
+                daySeparationWidthPadding,
+                plannerHeight,
+                currentHourIndicatorColor,
               );
             },
           );
         },
       ),
+    );
+  }
+
+  Widget _buildPlannerFixedExtentPage(
+    int pageIndex,
+    Color todayColor,
+    double daySeparationWidthPadding,
+    double plannerHeight,
+    Color currentHourIndicatorColor,
+  ) {
+    var pageDayCount = widget.daysWidthRatio!.length;
+    var firstDayIndex = pageIndex * pageDayCount;
+    for (var offset = 0; offset < pageDayCount; offset++) {
+      var day = getDayFromIndex(firstDayIndex + offset);
+      Future(() => widget.dayParam.onDayBuild?.call(day));
+    }
+
+    // The page has one fixed sliver extent; its child days keep their own
+    // widths from [daysWidthRatio].
+    return InfiniteListPage(
+      width: _horizontalItemExtent,
+      firstIndex: firstDayIndex,
+      itemCount: pageDayCount,
+      textDirection: widget.textDirection,
+      builder: (context, dayIndex) => _buildDayWidget(
+        dayIndex,
+        todayColor,
+        daySeparationWidthPadding,
+        plannerHeight,
+        currentHourIndicatorColor,
+      ),
+    );
+  }
+
+  Widget _buildDayWidget(
+    int dayIndex,
+    Color todayColor,
+    double daySeparationWidthPadding,
+    double plannerHeight,
+    Color currentHourIndicatorColor,
+  ) {
+    var day = getDayFromIndex(dayIndex);
+    return DayWidget(
+      // Avoid reusing arranged event state for a different date.
+      key: ValueKey(day),
+      controller: _controller,
+      textDirection: widget.textDirection,
+      day: day,
+      todayColor: todayColor,
+      daySeparationWidthPadding: daySeparationWidthPadding,
+      plannerHeight: plannerHeight,
+      heightPerMinute: heightPerMinute,
+      dayWidth: getDayWidth(day),
+      dayEventsArranger: widget.dayEventsArranger,
+      dayParam: widget.dayParam,
+      columnsParam: widget.columnsParam,
+      startColumnIndex: _startColumnIndex,
+      currentHourIndicatorParam: widget.currentHourIndicatorParam,
+      currentHourIndicatorColor: currentHourIndicatorColor,
+      offTimesParam: widget.offTimesParam,
+      showMultiDayEvents: !widget.fullDayParam.showMultiDayEvents,
     );
   }
 
@@ -601,6 +763,8 @@ class EventsPlannerState extends State<EventsPlanner> {
       dayWidthBuilder: getDayWidth,
       todayColor: todayColor,
       timesIndicatorsWidth: widget.timesIndicatorsParam.timesIndicatorsWidth,
+      fixedPageExtent: _horizontalItemExtent,
+      fixedPageItemCount: widget.daysWidthRatio?.length ?? 1,
     );
   }
 
@@ -621,6 +785,8 @@ class EventsPlannerState extends State<EventsPlanner> {
       dayWidthBuilder: getDayWidth,
       timesIndicatorsWidth: widget.timesIndicatorsParam.timesIndicatorsWidth,
       topLeftCellValueNotifier: topLeftCellValueNotifier,
+      fixedPageExtent: _horizontalItemExtent,
+      fixedPageItemCount: widget.daysWidthRatio?.length ?? 1,
     );
   }
 

--- a/lib/src/utils/list/infinite_list.dart
+++ b/lib/src/utils/list/infinite_list.dart
@@ -11,6 +11,40 @@ import 'models/types.dart';
 typedef ItemBuilder<I> = InfiniteListItem<I> Function(
     BuildContext context, I index);
 
+/// Builds a fixed-size list child from several logical item indices.
+///
+/// This lets callers keep variable-width content inside a stable sliver child.
+class InfiniteListPage extends StatelessWidget {
+  const InfiniteListPage({
+    super.key,
+    required this.width,
+    required this.firstIndex,
+    required this.itemCount,
+    required this.textDirection,
+    required this.builder,
+  });
+
+  final double? width;
+  final int firstIndex;
+  final int itemCount;
+  final TextDirection textDirection;
+  final Widget Function(BuildContext context, int index) builder;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: width,
+      child: Row(
+        textDirection: textDirection,
+        children: [
+          for (var offset = 0; offset < itemCount; offset++)
+            builder(context, firstIndex + offset),
+        ],
+      ),
+    );
+  }
+}
+
 /// List item build should return instance on this class
 ///
 /// It can be overriden if needed
@@ -229,6 +263,9 @@ class InfiniteList extends StatefulWidget {
   /// Proxy property for [ScrollView.physics]
   final ScrollPhysics? physics;
 
+  /// Uses fixed-extent slivers when all items have the same scroll size.
+  final double? itemExtent;
+
   final Key? _centerKey;
 
   const InfiniteList({
@@ -243,6 +280,7 @@ class InfiniteList extends StatefulWidget {
     this.cacheExtent,
     this.scrollDirection = Axis.vertical,
     this.physics,
+    this.itemExtent,
   }) : _centerKey = (direction == InfiniteListDirection.multi)
             ? const ValueKey<String>('center-key')
             : null;
@@ -255,7 +293,7 @@ class _InfiniteListState extends State<InfiniteList> {
   final StreamController<StickyState<int>> _streamController =
       StreamController<StickyState<int>>.broadcast();
 
-  SliverList get _reverseList => SliverList(
+  Widget get _reverseList => _buildSliver(
         delegate: SliverChildBuilderDelegate(
           (BuildContext context, int index) =>
               _buildListItem(context, (index + 1) * -1),
@@ -263,12 +301,12 @@ class _InfiniteListState extends State<InfiniteList> {
         ),
       );
 
-  SliverList get _forwardList => SliverList(
+  Widget get _forwardList => _buildSliver(
+        key: widget._centerKey,
         delegate: SliverChildBuilderDelegate(
           _buildListItem,
           childCount: widget.posChildCount,
         ),
-        key: widget._centerKey,
       );
 
   Widget _buildListItem(BuildContext context, int index) =>
@@ -278,7 +316,25 @@ class _InfiniteListState extends State<InfiniteList> {
         listItem: widget.builder(context, index),
       );
 
-  List<SliverList> get _slivers {
+  Widget _buildSliver({
+    Key? key,
+    required SliverChildDelegate delegate,
+  }) {
+    var itemExtent = widget.itemExtent;
+    if (itemExtent == null) {
+      return SliverList(
+        key: key,
+        delegate: delegate,
+      );
+    }
+    return SliverFixedExtentList(
+      key: key,
+      itemExtent: itemExtent,
+      delegate: delegate,
+    );
+  }
+
+  List<Widget> get _slivers {
     switch (widget.direction) {
       case InfiniteListDirection.multi:
         return [

--- a/lib/src/widgets/planner/day_widget.dart
+++ b/lib/src/widgets/planner/day_widget.dart
@@ -415,6 +415,21 @@ class _EventsListWidgetState extends State<EventsListWidget> {
     widget.controller.removeListener(eventListener);
   }
 
+  @override
+  void didUpdateWidget(covariant EventsListWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Event positions are arranged from the available width; ratio changes can
+    // make a reused day cell narrower or wider.
+    if (!DateUtils.isSameDay(oldWidget.day, widget.day) ||
+        oldWidget.dayWidth != widget.dayWidth ||
+        oldWidget.plannerHeight != widget.plannerHeight ||
+        oldWidget.dayEventsArranger != widget.dayEventsArranger ||
+        oldWidget.showMultiDayEvents != widget.showMultiDayEvents) {
+      events = getDayColumnEvents();
+      organizedEvents = getOrganizedEvents(events);
+    }
+  }
+
   List<Event>? getDayColumnEvents() {
     return widget.controller
         .getFilteredDayEvents(

--- a/lib/src/widgets/planner/draggable_event.dart
+++ b/lib/src/widgets/planner/draggable_event.dart
@@ -69,15 +69,15 @@ class DraggableEventWidget extends StatelessWidget {
         var relativeOffset = renderBox.globalToLocal(details.offset);
 
         // find day
+        var timeIndicatorWidth = plannerState?.widget.timesIndicatorsParam.timesIndicatorsWidth ?? 0;
+        var scrollOffsetX = plannerState?.mainHorizontalController.offset ?? 0;
+
+        var releaseOffsetX = scrollOffsetX + relativeOffset.dx - timeIndicatorWidth;
         var dayWidth = plannerState?.dayWidth ?? 0;
         var heightPerMinute = plannerState?.heightPerMinute ?? 0;
-        var scrollOffsetX = plannerState?.mainHorizontalController.offset ?? 0;
-        var releaseOffsetX = scrollOffsetX + relativeOffset.dx;
-        var dayIndex = (releaseOffsetX / dayWidth).toInt();
-        // adjust negative index, because current day begin 0 and negative begin -1
-        var reallyDayIndex = releaseOffsetX >= 0 ? dayIndex : dayIndex - 1;
+        var dayIndex = plannerState?.getIndexForOffset(releaseOffsetX, findExact: true) ?? 0;
         var currentDay = plannerState?.initialDate
-                .addCalendarDays(reallyDayIndex)
+                .addCalendarDays(dayIndex)
                 .withoutTime ??
             event.startTime.withoutTime;
 

--- a/lib/src/widgets/planner/draggable_event.dart
+++ b/lib/src/widgets/planner/draggable_event.dart
@@ -72,13 +72,18 @@ class DraggableEventWidget extends StatelessWidget {
         var timeIndicatorWidth = plannerState?.widget.timesIndicatorsParam.timesIndicatorsWidth ?? 0;
         var scrollOffsetX = plannerState?.mainHorizontalController.offset ?? 0;
 
-        var releaseOffsetX = scrollOffsetX + relativeOffset.dx - timeIndicatorWidth;
-        var dayWidth = plannerState?.dayWidth ?? 0;
+        // Use the ACTUAL event width for the midpoint calculation to fix the concurrent event bug.
+        // relativeOffset.dx points to the top-left corner of the dragged widget.
+        var releaseLeftOffsetX = scrollOffsetX + relativeOffset.dx - timeIndicatorWidth;
+        var releaseMidpointOffsetX = releaseLeftOffsetX + (width / 2);
+
         var heightPerMinute = plannerState?.heightPerMinute ?? 0;
-        var dayIndex = plannerState?.getIndexForOffset(releaseOffsetX, findExact: true) ?? 0;
+
+        // Use midpoint to calculate the exact destination day index
+        var dayIndex = plannerState?.getIndexForOffset(releaseMidpointOffsetX, findExact: true) ?? 0;
         var currentDay = plannerState?.initialDate
-                .addCalendarDays(dayIndex)
-                .withoutTime ??
+            .addCalendarDays(dayIndex)
+            .withoutTime ??
             event.startTime.withoutTime;
 
         // find hour
@@ -105,17 +110,24 @@ class DraggableEventWidget extends StatelessWidget {
         var totalMinutesRound =
             onSlotMinutesRound * (totalMinutes / onSlotMinutesRound).round();
         var roundStartDateTime =
-            currentDay.add(Duration(minutes: totalMinutesRound));
+        currentDay.add(Duration(minutes: totalMinutesRound));
         var roundEndDateTime =
-            roundStartDateTime.add(Duration(minutes: duration));
+        roundStartDateTime.add(Duration(minutes: duration));
 
         // find column
         var columnIndex = 0;
-        var dayPosition = (releaseOffsetX % dayWidth);
+
+        // Get the actual width of the destination day (important for daysWidthRatio)
+        var currentDayWidth = plannerState?.getDayWidth(currentDay) ?? plannerState?.dayWidth ?? 0;
+
+        // Find local offset within the specific day instead of modulo to support variable day widths
+        var offsetForDay = plannerState?.getOffsetForIndex(dayIndex) ?? 0;
+        var dayPosition = releaseMidpointOffsetX - offsetForDay;
+
         var columnsParam = plannerState?.widget.columnsParam;
         if (columnsParam != null && columnsParam.columns > 0) {
           for (var column = 0; column < columnsParam.columns; column++) {
-            var positions = columnsParam.getColumPositions(width, column);
+            var positions = columnsParam.getColumPositions(currentDayWidth, column);
             if (positions[0] <= dayPosition && dayPosition <= positions[1]) {
               columnIndex = column;
             }

--- a/lib/src/widgets/planner/horizontal_days_indicator_widget.dart
+++ b/lib/src/widgets/planner/horizontal_days_indicator_widget.dart
@@ -19,7 +19,7 @@ class HorizontalDaysIndicatorWidget extends StatelessWidget {
     required this.maxPreviousDays,
     required this.maxNextDays,
     required this.initialDate,
-    required this.dayWidth,
+    required this.dayWidthBuilder,
     required this.topLeftCellValueNotifier,
   });
 
@@ -33,7 +33,7 @@ class HorizontalDaysIndicatorWidget extends StatelessWidget {
   final int? maxPreviousDays;
   final int? maxNextDays;
   final DateTime initialDate;
-  final double dayWidth;
+  final double Function(DateTime) dayWidthBuilder;
   final ValueNotifier<DateTime> topLeftCellValueNotifier;
 
   @override
@@ -70,11 +70,12 @@ class HorizontalDaysIndicatorWidget extends StatelessWidget {
                 builder: (context, index) {
                   var day = getDayFromIndex(index);
                   var isToday = DateUtils.isSameDay(day, DateTime.now());
+                  var currentDayWidth = dayWidthBuilder(day);
 
                   return InfiniteListItem(
                     contentBuilder: (context) {
                       return SizedBox(
-                        width: dayWidth,
+                        width: currentDayWidth,
                         child: Column(
                           mainAxisAlignment: MainAxisAlignment.spaceAround,
                           children: [
@@ -87,7 +88,7 @@ class HorizontalDaysIndicatorWidget extends StatelessWidget {
                                 columnsParam.columnHeaderBuilder != null ||
                                 columnsParam.columnsLabels.isNotEmpty)
                               getColumnsHeader(context, startColumnIndex,
-                                  onColumnIndexChanged, day, isToday)
+                                  onColumnIndexChanged, day, isToday, currentDayWidth)
                           ],
                         ),
                       );
@@ -122,6 +123,7 @@ class HorizontalDaysIndicatorWidget extends StatelessWidget {
     Function(int newStartColumnIndex) onColumnIndexChanged,
     DateTime day,
     bool isToday,
+    double currentDayWidth,
   ) {
     var colorScheme = Theme.of(context).colorScheme;
     var bgColor = colorScheme.surface;
@@ -182,11 +184,11 @@ class HorizontalDaysIndicatorWidget extends StatelessWidget {
                 column++)
               if (builder != null)
                 builder.call(day, isToday, column,
-                    columnsParam.getColumSize(dayWidth, column))
+                    columnsParam.getColumSize(currentDayWidth, column))
               else
                 DefaultColumnHeader(
                   columnText: columnsParam.columnsLabels[column],
-                  columnWidth: columnsParam.getColumSize(dayWidth, column),
+                  columnWidth: columnsParam.getColumSize(currentDayWidth, column),
                   backgroundColor: columnsParam.columnsColors.isNotEmpty
                       ? columnsParam.columnsColors[column]
                       : bgColor,

--- a/lib/src/widgets/planner/horizontal_days_indicator_widget.dart
+++ b/lib/src/widgets/planner/horizontal_days_indicator_widget.dart
@@ -21,6 +21,8 @@ class HorizontalDaysIndicatorWidget extends StatelessWidget {
     required this.initialDate,
     required this.dayWidthBuilder,
     required this.topLeftCellValueNotifier,
+    this.fixedPageExtent,
+    this.fixedPageItemCount = 1,
   });
 
   final TextDirection textDirection;
@@ -35,6 +37,8 @@ class HorizontalDaysIndicatorWidget extends StatelessWidget {
   final DateTime initialDate;
   final double Function(DateTime) dayWidthBuilder;
   final ValueNotifier<DateTime> topLeftCellValueNotifier;
+  final double? fixedPageExtent;
+  final int fixedPageItemCount;
 
   @override
   Widget build(BuildContext context) {
@@ -65,32 +69,22 @@ class HorizontalDaysIndicatorWidget extends StatelessWidget {
                 physics: const NeverScrollableScrollPhysics(),
                 scrollDirection: Axis.horizontal,
                 direction: InfiniteListDirection.multi,
-                negChildCount: maxPreviousDays,
-                posChildCount: maxNextDays,
+                negChildCount: _itemCountForMaxDays(maxPreviousDays),
+                posChildCount: _itemCountForMaxDays(maxNextDays),
+                itemExtent: fixedPageExtent,
                 builder: (context, index) {
-                  var day = getDayFromIndex(index);
-                  var isToday = DateUtils.isSameDay(day, DateTime.now());
-                  var currentDayWidth = dayWidthBuilder(day);
-
                   return InfiniteListItem(
                     contentBuilder: (context) {
-                      return SizedBox(
-                        width: currentDayWidth,
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.spaceAround,
-                          children: [
-                            if (daysHeaderParam.daysHeaderVisibility)
-                              daysHeaderParam.dayHeaderBuilder != null
-                                  ? daysHeaderParam.dayHeaderBuilder!
-                                      .call(day, isToday)
-                                  : getDefaultDayHeader(day, isToday),
-                            if (columnsParam.columns > 1 ||
-                                columnsParam.columnHeaderBuilder != null ||
-                                columnsParam.columnsLabels.isNotEmpty)
-                              getColumnsHeader(context, startColumnIndex,
-                                  onColumnIndexChanged, day, isToday, currentDayWidth)
-                          ],
-                        ),
+                      if (fixedPageExtent == null) {
+                        return _buildDayCell(context, index);
+                      }
+                      // Match the planner body: fixed outer page, variable day cells.
+                      return InfiniteListPage(
+                        width: fixedPageExtent,
+                        firstIndex: index * fixedPageItemCount,
+                        itemCount: fixedPageItemCount,
+                        textDirection: textDirection,
+                        builder: _buildDayCell,
                       );
                     },
                   );
@@ -103,10 +97,41 @@ class HorizontalDaysIndicatorWidget extends StatelessWidget {
     );
   }
 
+  Widget _buildDayCell(BuildContext context, int dayIndex) {
+    var day = getDayFromIndex(dayIndex);
+    var isToday = DateUtils.isSameDay(day, DateTime.now());
+    var currentDayWidth = dayWidthBuilder(day);
+
+    return SizedBox(
+      width: currentDayWidth,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: [
+          if (daysHeaderParam.daysHeaderVisibility)
+            daysHeaderParam.dayHeaderBuilder != null
+                ? daysHeaderParam.dayHeaderBuilder!.call(day, isToday)
+                : getDefaultDayHeader(day, isToday),
+          if (columnsParam.columns > 1 ||
+              columnsParam.columnHeaderBuilder != null ||
+              columnsParam.columnsLabels.isNotEmpty)
+            getColumnsHeader(context, startColumnIndex,
+              onColumnIndexChanged, day, isToday, currentDayWidth)
+        ],
+      ),
+    );
+  }
+
   DateTime getDayFromIndex(int index) {
     return initialDate
         .addCalendarDays(textDirection == TextDirection.ltr ? index : -index);
   }
+
+  // Child counts are still configured in days; fixed pages group several days
+  // into one sliver child.
+  int? _itemCountForMaxDays(int? maxDays) =>
+      fixedPageExtent == null || maxDays == null
+          ? maxDays
+          : (maxDays / fixedPageItemCount).ceil();
 
   DefaultDayHeader getDefaultDayHeader(DateTime day, bool isToday) {
     return DefaultDayHeader(

--- a/lib/src/widgets/planner/horizontal_full_day_events_widget.dart
+++ b/lib/src/widgets/planner/horizontal_full_day_events_widget.dart
@@ -17,7 +17,7 @@ class HorizontalFullDayEventsWidget extends StatelessWidget {
     required this.maxPreviousDays,
     required this.maxNextDays,
     required this.initialDate,
-    required this.dayWidth,
+    required this.dayWidthBuilder,
     required this.todayColor,
     required this.timesIndicatorsWidth,
   });
@@ -31,7 +31,7 @@ class HorizontalFullDayEventsWidget extends StatelessWidget {
   final int? maxPreviousDays;
   final int? maxNextDays;
   final DateTime initialDate;
-  final double dayWidth;
+  final double Function(DateTime) dayWidthBuilder;
   final Color? todayColor;
   final double timesIndicatorsWidth;
 
@@ -73,10 +73,12 @@ class HorizontalFullDayEventsWidget extends StatelessWidget {
                   builder: (context, index) {
                     var day = getDayFromIndex(index);
                     var isToday = DateUtils.isSameDay(day, DateTime.now());
+                    var currentDayWidth = dayWidthBuilder(day);
+
                     return InfiniteListItem(
                       contentBuilder: (context) {
                         return SizedBox(
-                          width: dayWidth,
+                          width: currentDayWidth,
                           child: FullDayEventsWidget(
                             controller: controller,
                             isToday: isToday,
@@ -84,7 +86,7 @@ class HorizontalFullDayEventsWidget extends StatelessWidget {
                             todayColor: todayColor,
                             fullDayParam: fullDayParam,
                             columnsParam: columnsParam,
-                            dayWidth: dayWidth,
+                            dayWidth: currentDayWidth,
                             daySeparationWidthPadding:
                                 daySeparationWidthPadding,
                           ),

--- a/lib/src/widgets/planner/horizontal_full_day_events_widget.dart
+++ b/lib/src/widgets/planner/horizontal_full_day_events_widget.dart
@@ -20,6 +20,8 @@ class HorizontalFullDayEventsWidget extends StatelessWidget {
     required this.dayWidthBuilder,
     required this.todayColor,
     required this.timesIndicatorsWidth,
+    this.fixedPageExtent,
+    this.fixedPageItemCount = 1,
   });
 
   final EventsController controller;
@@ -34,6 +36,8 @@ class HorizontalFullDayEventsWidget extends StatelessWidget {
   final double Function(DateTime) dayWidthBuilder;
   final Color? todayColor;
   final double timesIndicatorsWidth;
+  final double? fixedPageExtent;
+  final int fixedPageItemCount;
 
   @override
   Widget build(BuildContext context) {
@@ -64,39 +68,56 @@ class HorizontalFullDayEventsWidget extends StatelessWidget {
             child: SizedBox(
               height: fullDayParam.fullDayEventsBarHeight,
               child: InfiniteList(
-                  controller: dayHorizontalController,
-                  physics: const NeverScrollableScrollPhysics(),
-                  scrollDirection: Axis.horizontal,
-                  direction: InfiniteListDirection.multi,
-                  negChildCount: maxPreviousDays,
-                  posChildCount: maxNextDays,
-                  builder: (context, index) {
-                    var day = getDayFromIndex(index);
-                    var isToday = DateUtils.isSameDay(day, DateTime.now());
-                    var currentDayWidth = dayWidthBuilder(day);
-
-                    return InfiniteListItem(
-                      contentBuilder: (context) {
-                        return SizedBox(
-                          width: currentDayWidth,
-                          child: FullDayEventsWidget(
-                            controller: controller,
-                            isToday: isToday,
-                            day: day,
-                            todayColor: todayColor,
-                            fullDayParam: fullDayParam,
-                            columnsParam: columnsParam,
-                            dayWidth: currentDayWidth,
-                            daySeparationWidthPadding:
-                                daySeparationWidthPadding,
-                          ),
-                        );
-                      },
-                    );
-                  }),
+                controller: dayHorizontalController,
+                physics: const NeverScrollableScrollPhysics(),
+                scrollDirection: Axis.horizontal,
+                direction: InfiniteListDirection.multi,
+                negChildCount: _itemCountForMaxDays(maxPreviousDays),
+                posChildCount: _itemCountForMaxDays(maxNextDays),
+                itemExtent: fixedPageExtent,
+                builder: (context, index) {
+                  return InfiniteListItem(
+                    contentBuilder: (context) {
+                      if (fixedPageExtent == null) {
+                        return _buildFullDayEventsCell(index);
+                      }
+                      // Match the planner body: fixed outer page, variable day cells.
+                      return InfiniteListPage(
+                        width: fixedPageExtent,
+                        firstIndex: index * fixedPageItemCount,
+                        itemCount: fixedPageItemCount,
+                        textDirection: textDirection,
+                        builder: (_, index) => _buildFullDayEventsCell(index),
+                      );
+                    },
+                  );
+                },
+              ),
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildFullDayEventsCell(int dayIndex) {
+    var day = getDayFromIndex(dayIndex);
+    var isToday = DateUtils.isSameDay(day, DateTime.now());
+    var currentDayWidth = dayWidthBuilder(day);
+
+    return SizedBox(
+      width: currentDayWidth,
+      child: FullDayEventsWidget(
+        // Full-day widgets cache events, so do not reuse state across dates.
+        key: ValueKey(day),
+        controller: controller,
+        isToday: isToday,
+        day: day,
+        todayColor: todayColor,
+        fullDayParam: fullDayParam,
+        columnsParam: columnsParam,
+        dayWidth: currentDayWidth,
+        daySeparationWidthPadding: daySeparationWidthPadding,
       ),
     );
   }
@@ -105,6 +126,13 @@ class HorizontalFullDayEventsWidget extends StatelessWidget {
     return initialDate
         .addCalendarDays(textDirection == TextDirection.ltr ? index : -index);
   }
+
+  // Child counts are still configured in days; fixed pages group several days
+  // into one sliver child.
+  int? _itemCountForMaxDays(int? maxDays) =>
+      fixedPageExtent == null || maxDays == null
+          ? maxDays
+          : (maxDays / fixedPageItemCount).ceil();
 }
 
 class FullDayEventsWidget extends StatefulWidget {
@@ -152,6 +180,17 @@ class _FullDayEventsWidgetState extends State<FullDayEventsWidget> {
   void dispose() {
     super.dispose();
     widget.controller.removeListener(eventListener);
+  }
+
+  @override
+  void didUpdateWidget(covariant FullDayEventsWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // The state caches filtered events, but fixed pages can reuse it for a different date.
+    if (!DateUtils.isSameDay(oldWidget.day, widget.day) ||
+        oldWidget.fullDayParam.showMultiDayEvents !=
+            widget.fullDayParam.showMultiDayEvents) {
+      updateEvents();
+    }
   }
 
   void updateEvents() {


### PR DESCRIPTION
# Description

This PR introduces the ability to set custom flex widths for individual days and fixes a long-standing offset bug with the drag-and-drop feature.

**Changes made:**
1. **Added `daysWidthRatio` feature:** Introduced an optional `List<double>? daysWidthRatio` property to `EventsPlanner`. This allows users to set custom width ratios for the 7 days of the week (e.g., making weekends smaller). 
2. **Dynamic Grid Calculations:** Implemented `getDayWidth`, `getOffsetForIndex`, and `getIndexForOffset` in `EventsPlannerState` to accurately calculate scroll snapping and grid placement when days have variable widths. These methods safely fallback to the original behavior if `daysWidthRatio` is null.
3. **Fixed Drag-and-drop offset bug:** In `DraggableEventWidget`, dropping an event previously miscalculated the horizontal day index because the global-to-local coordinate mapping did not account for the `timesIndicatorsWidth` on the left side of the screen. This PR fixes the drop X-coordinate by subtracting the timeline width and utilizing `getIndexForOffset(..., findExact: true)` to ensure the event drops exactly onto the boundary it hovers over.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues

Resolves #36 